### PR TITLE
Fix functions before dot

### DIFF
--- a/example.esql
+++ b/example.esql
@@ -1,6 +1,6 @@
 // This is a comment, not a "string"
  /*asdf*/  EXPLAIN [ FROM index, "this=that", <logs-{now/d}> ]
-  | FROM index, cluster:index, "another_index", """index""" METADATA _id, _index
+  | FROM index, metrics:index, "another_index", """index""", metrics-metrics-metrics METADATA _id, _index
   | ROW num = 123, another_field = "value", arr.nested = [1, 2, 3], nested.`escaped`.??param = NULL
   /* This is a multiline
      comment */
@@ -13,7 +13,7 @@
   | WHERE process.name == "curl.exe /* asdf */" AND ?42 == 123 OR ?
   | WHERE event_duration > /* very big number */ 5000000
   | WHERE message LIKE "Connected*"
-  | KEEP kb, destination.address, date, ip, email, num
+  | KEEP kb, destination.address, date, ip, email, num, avg.avg.avg
   // The ten is
   // very sensible number
   | LIMIT 10

--- a/src/monarch.ts
+++ b/src/monarch.ts
@@ -55,7 +55,7 @@ export const create = (
 
 				// Keywords
 				[
-					/@?[a-zA-Z_$][\w$]*/,
+					/@?[a-zA-Z_$][\w$]*(?!\s*\.)/,
 					{
 						cases: {
 							"@sourceCommands": { token: "keyword.command.source.$0" },

--- a/src/monarch.ts
+++ b/src/monarch.ts
@@ -55,7 +55,7 @@ export const create = (
 
 				// Keywords
 				[
-					/@?[a-zA-Z_$][\w$]*(?!\s*\.)/,
+					/@?[a-zA-Z_$][\w$]*(?!\s*[\.\-:])/,
 					{
 						cases: {
 							"@sourceCommands": { token: "keyword.command.source.$0" },


### PR DESCRIPTION
This fix does not highlight tokens as functions in case they are followed by a dot `.` or `-` or `:` tokens. This change removes large amount of index pattern and nested field miscoloring.