### PR TITLE
[ES|QL] Fix float highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ monaco.languages.setMonarchTokensProvider('esql', monarchLanguage);
 Publish with `release-it` tool:
 
 ```
+yarn build
 npx release-it
 ```
 

--- a/example.esql
+++ b/example.esql
@@ -5,7 +5,7 @@
   /* This is a multiline
      comment */
   | SHOW INFO
-  | FORK (WHERE ?param.test = "asdf" | LIMIT 123) (LIMIT 123)
+  | FORK (WHERE ?param.test = "asdf" | LIMIT 123) (LIMIT 123) (SAMPLE .01)
   | NEW_COMMAND "hello"
   | UNKNOWN_COMMAND
   | METRICS index_pattern, logs-* BY date, ip

--- a/src/monarch.ts
+++ b/src/monarch.ts
@@ -56,7 +56,7 @@ export const create = (
 
 				// Keywords
 				[
-					/@?[a-zA-Z_$][\w$]*(?!\s*[\.\-:])/,
+					/@?[a-zA-Z_$][\w$]*(?![\.\-:])/,
 					{
 						cases: {
 							"@sourceCommands": { token: "keyword.command.source.$0" },
@@ -184,7 +184,7 @@ export const create = (
 
 			number: [
 				[/(@digits)[eE]([\-+]?(@digits))?/, "number.float"],
-				[/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, "number.float"],
+				[/(@digits)?\.(@digits)([eE][\-+]?(@digits))?/, "number.float"],
 				[/(@digits)/, "number"],
 			],
 


### PR DESCRIPTION
### Summary of changes
Detect `.01` float forms.

This regex `/@?[a-zA-Z_$][\w$]*(?!\s*[\.\-:])/` prevents strings like `SAMPLE .01` to match.
The reason is that ` (?!\s*[\.\-:])` makes the regex not match if the keyword is followed by any amount of spaces and a dot, score or two dots.
Taking out the white spaces from it will fix the case for `SAMPLE .01`.

@vadimkibana do you remember why the spaces where needed?

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/7e195615-0b82-4471-83b2-a4d5fcbb28c7) | ![image](https://github.com/user-attachments/assets/703e0694-66ba-487b-bdd9-a1a46126bf8e) 
![image](https://github.com/user-attachments/assets/7ef6f0a4-b91d-4ba9-a9d5-18b9dd79de56) |  ![image](https://github.com/user-attachments/assets/e95b8fe9-439b-4d19-96b4-558e3f853921) 


