### PR TITLE
build: remove registry URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "3.3.0",
   "private": false,
   "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
+    "access": "public"
   },
   "description": "Monaco editor Monarch language syntax definitions for ES|QL",
   "main": "lib/index.js",


### PR DESCRIPTION
Having the registry URL set in `actions/setup-node` seems to automatically set `NPM_TOKEN=GITHUB_TOKEN`, disabling the authentication via OIDC. 
This produces a 401 when trying to publish the package to npm.