### PR TITLE
feat: Highlight  parameters in a PromQL query

### DIFF
--- a/src/promql.ts
+++ b/src/promql.ts
@@ -94,6 +94,12 @@ export const promQLQuery: languages.IMonarchLanguageRule[] = [
 		{ token: "string", next: "@promqlBacktickString", nextEmbedded: "@pop" },
 	],
 
+	// variables control handling
+	[
+		/\?{1,9}/,
+		{ token: "@rematch", next: "@promqlParamReference", nextEmbedded: "@pop" },
+	],
+
 	// Exit condition
 	[
 		/\|/,
@@ -137,6 +143,25 @@ const promQLQueryOverrideRules: {
 		[/[^`\\]+/, "string"],
 		[/\\./, "string.escape"],
 		[/`/, { token: "string", next: "@pop", nextEmbedded: "promql" }],
+	],
+
+	promqlParamReference: [
+		[
+			/\?{1,9}[a-zA-Z_][a-zA-Z_0-9]*/,
+			{ token: "variable.name.named", next: "@pop", nextEmbedded: "promql" },
+		],
+		[
+			/\?{1,9}[0-9]+/,
+			{
+				token: "variable.name.positional",
+				next: "@pop",
+				nextEmbedded: "promql",
+			},
+		],
+		[
+			/\?{1,9}/,
+			{ token: "variable.name.unnamed", next: "@pop", nextEmbedded: "promql" },
+		],
 	],
 };
 


### PR DESCRIPTION
Added a state in the `PromQL `tokenizer to color `esql` parameters inside a `PromQL `query 
(The regexes use the same parameters forms the standard `esql`)

<img width="393" height="72" alt="color" src="https://github.com/user-attachments/assets/511e1192-4d29-4ed9-9c42-bdb1131cbd0e" />

